### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ OpenHRC includes some tools for HRC like a robot controller for multiple robots 
 OpenHRC has been developed and tested in the following environments:
 - Development Environment: Ubuntu 22.04 (ROS2 Humble)
 
-**If you want to use ROS1 version, please checkout the `noetic` branch, which is no longer maintained.**
+**If you want to use ROS1 version, please checkout the [`noetic`](https://github.com/Automation-Research-Team/OpenHRC/tree/noetic) branch, which is no longer maintained.**
 
 
 
@@ -26,13 +26,12 @@ We use [rocker](https://github.com/osrf/rocker) here to simply run the docker co
 ```bash
 $ git clone https://github.com/Automation-Research-Team/OpenHRC.git -b ros2
 $ docker build -t openhrc:ros2 docker/.
-
-$ sudo apt install python3-rocker # if you don't have rocker. You can also use "pip install rocker".
 ```
 
 ### Run
 Now you can control the end-effector of UR5e with an interactive marker.
 ```bash
+$ sudo apt install python3-rocker # if you don't have rocker. You can also use "pip install rocker".
 $ rocker --x11 openhrc:ros2 marker_teleoperation_ur5e 
 ```
 
@@ -50,8 +49,7 @@ In the following instruction, the ros2 workspace directory is assumed to be `~/r
 
 ### Clone the Source Code and install dependencies
 ```bash
-$ mkdir -p ~/ros2_ws/src
-$ cd ~/ros2_ws/src
+$ mkdir -p ~/ros2_ws/src && cd ~/ros2_ws/src
 $ git clone https://github.com/Automation-Research-Team/OpenHRC.git -b ros2 --recursive
 $ rosdep update && rosdep install -i -y --from-paths ./ 
 ```
@@ -69,7 +67,7 @@ $ colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
 ## Getting Started
 You can first try the teleoperation node with interactive markers for UR5e.
 
-First, run the following command to start the UR5e simulation, which has been installed automatically with OpenHRC:
+First, run the following command to start the UR5e gazebo simulation, which has been installed automatically with OpenHRC:
 ```bash
 $ ros2 launch ur_simulation_gz ur_sim_control.launch.py initial_joint_controller:=forward_velocity_controller launch_rviz:=false
 ```
@@ -120,8 +118,8 @@ This software is released under dual license of LGPL-v2.1 and individual license
 About the individual license, please make a contact to the author.
 
 ## Author
-Shunki Itadera (https://itadera.github.io/) - Researcher at ART, ICPS, AIST
+Shunki Itadera (https://itadera.github.io/) - Researcher at AIST, Japan
 
 We welcome any feedback and contributions. Please feel free to contact us if you have any questions or comments.
 
-Besides, we are looking for research collaborators and students who are interested in Human-Robot Interaction using OpenHRC. If you are interested, please send me an email.
+Besides, we are looking for research collaborators and students who are interested in Human-Robot Interaction using OpenHRC. If you are interested, please send me a message.

--- a/README.md
+++ b/README.md
@@ -69,19 +69,8 @@ $ colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
 ## Getting Started
 You can first try the teleoperation node with interactive markers for UR5e.
 
-If you have not installed UR5e simulation yet, open a terminal and run:
+First, run the following command to start the UR5e simulation, which has been installed automatically with OpenHRC:
 ```bash
-$ cd ~/ros2_ws/src
-$ git clone https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation.git -b humble
-$ rosdep update && rosdep install -i -y --from-paths ./ 
-
-$ cd ~/ros2_ws
-$ colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
-```
-
-First, run the following command to start the UR5e simulation.:
-```bash
-$ source ~/ros2_ws/install/setup.bash
 $ ros2 launch ur_simulation_gz ur_sim_control.launch.py initial_joint_controller:=forward_velocity_controller launch_rviz:=false
 ```
 
@@ -92,7 +81,7 @@ $ ros2 launch ohrc_teleoperation marker_teleoperation.launch.py
 ```
 
 
-If you have a 3D mouse (spacenav), you can also use it for teleoperation instead of interactive marker.
+If you have a 3D mouse (spacenav), you can also use it for teleoperation instead.
 ```bash
 $ source ~/ros2_ws/install/setup.bash
 $ sudo apt install ros-humble-spacenav # if you don't have spacenav package
@@ -100,10 +89,16 @@ $ ros2 launch ohrc_teleoperation joy_topic_teleoperation.launch.py
 ```
 
 
+## Controller Structure
+*Under development
+
+see [ohrc_control/README.md](./ohrc_control/README.md)
+
+
 ## Tutorials
 *Under development
-1. Teleoperation library: [ohrc_teleoperation](./ohrc_teleoperation)
-2. Imitation Learning library: [ohrc_imitation_learning](./ohrc_imitation_learning)
+1. Teleoperation library: [ohrc_teleoperation/README.md](./ohrc_teleoperation)
+2. Imitation Learning library: [ohrc_imitation_learning/README.md](./ohrc_imitation_learning)
 
 
 

--- a/ohrc_control/README.md
+++ b/ohrc_control/README.md
@@ -1,0 +1,23 @@
+
+# Controller Structure
+
+Within the ROS (ROS 2) ecosystem, we offer two types of controller structures:
+1. Topic-based controller  
+2. Realtime controller (coming soon)
+
+
+
+## 1. Topic-based Controller
+
+This is the simplest way (in our opinion) to control a robot by taking advantage of ROS's pub/sub system.
+
+If the robot can receive command topics such as joint velocity commands, this method can be used with minimal setup—typically just adjusting parameters like the robot's namespace and topic names.
+
+However, this control scheme relies on ROS topic communication between the robot and controller nodes, and it does **not** guarantee real-time loop performance. In practice, this usually isn’t a problem. But for high-frequency force control (e.g., 1 kHz control for a Franka robot), this method may lead to unstable behavior.
+
+
+## 2. Realtime Controller
+
+This approach involves controlling the robot using a real-time kernel on the host PC.  
+(It is not yet available, but we plan to support it.)
+

--- a/ohrc_hw_config/package.xml
+++ b/ohrc_hw_config/package.xml
@@ -13,6 +13,7 @@
   <!-- One license tag required, multiple allowed, one license per tag -->
   <!-- Commonly used license strings: -->
   <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <exec_depend>ur_simulation_gz</exec_depend>
   <license>TODO</license>
 
 


### PR DESCRIPTION
This pull request includes several updates to the `README.md` file to improve clarity and provide additional information, as well as the addition of a new `README.md` file for the `ohrc_control` package. The most important changes include providing a link to the `noetic` branch, reordering installation steps, and adding a new section on the controller structure.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-R16): Added a link to the `noetic` branch for users who want to use the ROS1 version.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L29-R34): Reordered the installation steps to ensure `rocker` is installed before running the docker container.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L53-R52): Combined the commands for creating and navigating to the workspace directory into a single line.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L72-L84): Updated the instructions to start the UR5e gazebo simulation, reflecting that it is installed automatically with OpenHRC.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L95-R99): Added a new section on the controller structure, linking to the `ohrc_control/README.md` file.

New documentation:

* [`ohrc_control/README.md`](diffhunk://#diff-11fd8c3e648860d1d62262658af5063e9a6be44ca158cf5c025c4050684c8511R1-R23): Added a new `README.md` file detailing the controller structure, including topic-based and real-time controllers.

Dependency updates:

* [`ohrc_hw_config/package.xml`](diffhunk://#diff-ed3f6272641a2a91d7b31be8022ac998d0a7bcc2ecd516548a869f69ebd07bcfR16): Added `ur_simulation_gz` as an execution dependency.