### PR TITLE
Hsd

### DIFF
--- a/ohrc_control/src/cart_controller.cpp
+++ b/ohrc_control/src/cart_controller.cpp
@@ -500,12 +500,12 @@ int CartController::moveInitPos(const KDL::JntArray& q_cur, const KDL::JntArray&
   this->initCmd_.flag = true;
 
   if (lastLoop) {
-    if ((q_des_t - q_cur.data).norm() < 1.0e-4 && dq_cur.data.norm() < 1.0e-3 && s == 1.0) {  // TODO: check these thresholds
+    if ((q_des_t - q_cur.data).norm() < 1.0e-3 && dq_cur.data.norm() < 1.0e-3 && s == 1.0) {  // TODO: check these thresholds
       RCLCPP_INFO_STREAM(node->get_logger(), "The robot (ns: " + robot_ns + ") has reached the initial pose.");
       reseted = true;
       return true;
     }
-    // RCLCPP_INFO_STREAM(node->get_logger(), "Reaching error > pos:" << (q_des_t - q_cur.data).norm() << ", vel:" << dq_cur.data.norm());
+    RCLCPP_WARN_STREAM_THROTTLE(node->get_logger(), *(node->get_clock()), 1000, "Reaching error > pos:" << (q_des_t - q_cur.data).norm() << ", vel:" << dq_cur.data.norm());
     // feedback_gain += 0.1 / freq;
   }
 

--- a/ohrc_control/src/my_ik.cpp
+++ b/ohrc_control/src/my_ik.cpp
@@ -500,8 +500,8 @@ int MyIK::CartToJntVel_qp(const std::vector<KDL::JntArray>& q_cur, const std::ve
   std::vector<VectorXd> es(nRobot);
   std::vector<Matrix<double, 6, 1>> vs(nRobot);
 
-  VectorXd kp = 3.0 * VectorXd::Ones(6);  // TODO: make this p gain as ros param
-  kp.tail(3) = kp.tail(3) * 0.5 / M_PI * 0.5;
+  // VectorXd kp = 3.0 * VectorXd::Ones(6);  // TODO: make this p gain as ros param <- NO LONGER USED
+  // kp.tail(3) = kp.tail(3) * 0.5 / M_PI * 0.5;
 
   for (size_t i = 0; i < nRobot; i++) {
     KDL::Jacobian jac(myIKs[i]->getNJnt());
@@ -534,7 +534,7 @@ int MyIK::CartToJntVel_qp(const std::vector<KDL::JntArray>& q_cur, const std::ve
   std::vector<VectorXd> g(nRobot + nAddObj);
 
   // additonal objective term in QP (1) for singularity avoidance
-  w_h[nRobot] = 1.0e-0;
+  w_h[nRobot] = 5.0e-0;
   H[nRobot] = MatrixXd::Identity(nState, nState);
   g[nRobot] = VectorXd::Zero(nState);  // this will be updated in the loop below
 

--- a/ohrc_control/src/my_ik.cpp
+++ b/ohrc_control/src/my_ik.cpp
@@ -500,9 +500,7 @@ int MyIK::CartToJntVel_qp(const std::vector<KDL::JntArray>& q_cur, const std::ve
   std::vector<VectorXd> es(nRobot);
   std::vector<Matrix<double, 6, 1>> vs(nRobot);
 
-  // VectorXd kp = 3.0 * VectorXd::Ones(6);  // TODO: make this p gain as ros param <- NO LONGER USED
-  // kp.tail(3) = kp.tail(3) * 0.5 / M_PI * 0.5;
-
+// Removed unused proportional gain initialization code to reduce clutter.
   for (size_t i = 0; i < nRobot; i++) {
     KDL::Jacobian jac(myIKs[i]->getNJnt());
 


### PR DESCRIPTION
This pull request includes adjustments to control thresholds and parameters in the `ohrc_control` module, specifically in the `CartController` and `MyIK` classes. The changes focus on fine-tuning tolerances, removing unused code, and updating weights for singularity avoidance in the QP formulation.

### Threshold and Parameter Adjustments:
* [`ohrc_control/src/cart_controller.cpp`](diffhunk://#diff-c1bb1f0b1eb3583f0997861ed40567686085b1840ccc95ad39def0928e59344dL478-R478): Adjusted the position error threshold (`q_error`) in the `moveInitPos` method from `1.0e-4` to `1.0e-3` to relax the tolerance for determining when the robot has reached the initial pose.

* [`ohrc_control/src/my_ik.cpp`](diffhunk://#diff-229d6e6a2903d608e4bf643da07bfd258e737b375910409fd94084fb386a3b77L537-R537): Increased the weight for singularity avoidance (`w_h[nRobot]`) from `1.0e-0` to `5.0e-0` in the `CartToJntVel_qp` method to prioritize this objective in the QP formulation.

### Code Cleanup:
* [`ohrc_control/src/my_ik.cpp`](diffhunk://#diff-229d6e6a2903d608e4bf643da07bfd258e737b375910409fd94084fb386a3b77L503-R504): Commented out and marked as unused the proportional gain (`kp`) initialization code in the `CartToJntVel_qp` method, as it is no longer required.